### PR TITLE
feat(models): add audit and intervention_equipement

### DIFF
--- a/app/db/database.py
+++ b/app/db/database.py
@@ -6,6 +6,7 @@ from app.core.config import settings
 
 # Initialisation de Base
 Base = declarative_base()
+Base.__allow_unmapped__ = True  # SQLAlchemy 2.x compat: allow legacy type hints
 
 # Production engine par défaut
 DATABASE_URL = (

--- a/app/db/migrations/versions/73106f3ecd3c_add_audit_and_intervention_equipement.py
+++ b/app/db/migrations/versions/73106f3ecd3c_add_audit_and_intervention_equipement.py
@@ -1,0 +1,49 @@
+"""add audit and intervention_equipement
+
+Revision ID: 73106f3ecd3c
+Revises: df44b376bc8a
+Create Date: 2025-08-06 15:04:05.699265
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "73106f3ecd3c"
+down_revision: Union[str, Sequence[str], None] = "df44b376bc8a"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create audit and intervention_equipement tables."""
+    op.create_table(
+        "audits",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("action", sa.String(length=255), nullable=False),
+        sa.Column("table_name", sa.String(length=255), nullable=False),
+        sa.Column("object_id", sa.Integer(), nullable=True),
+        sa.Column("details", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id", ondelete="SET NULL"), nullable=True),
+        sa.Index("idx_audit_table_object", "table_name", "object_id"),
+        sa.Index("idx_audit_user_date", "user_id", "created_at"),
+    )
+
+    op.create_table(
+        "interventions_equipements",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("intervention_id", sa.Integer(), sa.ForeignKey("interventions.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("equipement_id", sa.Integer(), sa.ForeignKey("equipements.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Index("idx_intervention_equipement", "intervention_id", "equipement_id"),
+    )
+
+
+def downgrade() -> None:
+    """Drop audit and intervention_equipement tables."""
+    op.drop_table("interventions_equipements")
+    op.drop_table("audits")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -50,11 +50,12 @@ from .equipement import (
 
 # Modèles interventions - cœur métier
 from .intervention import (
-    Intervention, 
-    InterventionType, 
+    Intervention,
+    InterventionType,
     StatutIntervention,
     PrioriteIntervention
 )
+from .intervention_equipement import InterventionEquipement
 
 # Modèles planification et organisation
 from .planning import Planning
@@ -67,6 +68,7 @@ from .notification import Notification
 
 # Modèles audit et traçabilité
 from .historique import HistoriqueIntervention
+from .audit import Audit
 
 # Modèles contractuels et commerciaux
 from .contrat import Contrat, Facture, TypeContrat, StatutContrat
@@ -105,6 +107,7 @@ __all__ = [
     
     # Interventions - métier principal
     "Intervention", "InterventionType", "StatutIntervention", "PrioriteIntervention",
+    "InterventionEquipement",
     
     # Organisation et planification
     "Planning",
@@ -116,7 +119,7 @@ __all__ = [
     "Notification", 
     
     # Audit et traçabilité
-    "HistoriqueIntervention",
+    "HistoriqueIntervention", "Audit",
     
     # Commercial et contrats
     "Contrat", "Facture", "TypeContrat", "StatutContrat",

--- a/app/models/audit.py
+++ b/app/models/audit.py
@@ -1,0 +1,69 @@
+"""
+Modèle Audit : journalisation des actions utilisateur pour la traçabilité.
+
+- N:1 avec User
+- Enregistre l'action, la table ciblée et l'horodatage
+"""
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Dict, Any, Optional
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    Index,
+)
+from sqlalchemy.orm import relationship
+
+from app.db.database import Base
+
+if TYPE_CHECKING:  # pragma: no cover - uniquement pour les types
+    from .user import User
+
+
+class Audit(Base):
+    """Journal des actions réalisées dans le système."""
+
+    __tablename__ = "audits"
+    __table_args__ = (
+        Index("idx_audit_table_object", "table_name", "object_id"),
+        Index("idx_audit_user_date", "user_id", "created_at"),
+    )
+
+    id: int = Column(Integer, primary_key=True, index=True)
+    action: str = Column(String(255), nullable=False, index=True)
+    table_name: str = Column(String(255), nullable=False, index=True)
+    object_id: Optional[int] = Column(Integer, nullable=True, index=True)
+    details: Optional[str] = Column(Text, nullable=True)
+    created_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False, index=True)
+
+    user_id: Optional[int] = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
+    user: "User" = relationship("User", back_populates="audits", lazy="select")
+
+    def to_dict(self, include_relations: bool = False) -> Dict[str, Any]:
+        data = {
+            "id": self.id,
+            "action": self.action,
+            "table_name": self.table_name,
+            "object_id": self.object_id,
+            "details": self.details,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "user_id": self.user_id,
+        }
+        if include_relations:
+            data["user"] = self.user.to_dict() if self.user else None
+        return data
+
+
+__all__ = ["Audit"]
+

--- a/app/models/contrat.py
+++ b/app/models/contrat.py
@@ -113,6 +113,13 @@ class Contrat(Base):
         lazy="dynamic"
     )
 
+    equipements = relationship(
+        "Equipement",
+        back_populates="contrat",
+        cascade="all, delete-orphan",
+        lazy="dynamic"
+    )
+
     def __repr__(self) -> str:
         return f"<Contrat(id={self.id}, numero='{self.numero_contrat}', client='{self.client_id}')>"
 

--- a/app/models/equipement.py
+++ b/app/models/equipement.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from .planning import Planning
     from .client import Client
     from .contrat import Contrat
+    from .intervention_equipement import InterventionEquipement
 
 
 class StatutEquipement(str, enum.Enum):
@@ -164,11 +165,18 @@ class Equipement(Base):
     )
     
     plannings = relationship(
-        "Planning", 
-        back_populates="equipement", 
+        "Planning",
+        back_populates="equipement",
         cascade="all, delete-orphan",
         lazy="dynamic",
-        order_by="Planning.date_prevue"
+        order_by="Planning.prochaine_date"
+    )
+
+    interventions_assoc = relationship(
+        "InterventionEquipement",
+        back_populates="equipement",
+        cascade="all, delete-orphan",
+        lazy="dynamic",
     )
 
     def __repr__(self) -> str:
@@ -385,7 +393,7 @@ class Equipement(Base):
     def get_planning_maintenance(self) -> List["Planning"]:
         """Retourne les maintenances planifiées à venir."""
         return list(self.plannings.filter(
-            Planning.date_prevue >= datetime.utcnow()
+            Planning.prochaine_date >= datetime.utcnow()
         ).all())
 
     def peut_etre_supprime(self) -> bool:

--- a/app/models/intervention.py
+++ b/app/models/intervention.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
     from .historique import HistoriqueIntervention
     from .notification import Notification
     from .stock import MouvementStock, InterventionPiece
+    from .intervention_equipement import InterventionEquipement
 
 
 class InterventionType(str, enum.Enum):
@@ -128,10 +129,10 @@ class Intervention(Base):
     __table_args__ = (
         Index('idx_intervention_statut_priorite', 'statut', 'priorite'),
         Index('idx_intervention_technicien_statut', 'technicien_id', 'statut'),
-        Index('idx_intervention_equipement_type', 'equipement_id', 'type_intervention'),
+        Index('idx_intervention_equipement_type', 'equipement_id', 'type'),
         Index('idx_intervention_client_statut', 'client_id', 'statut'),
         Index('idx_intervention_dates', 'date_creation', 'date_limite'),
-        Index('idx_intervention_type_urgence', 'type_intervention', 'urgence'),
+        Index('idx_intervention_type_urgence', 'type', 'urgence'),
     )
 
     # Clé primaire
@@ -197,19 +198,26 @@ class Intervention(Base):
     )
     
     technicien: Optional["Technicien"] = relationship(
-        "Technicien", 
-        back_populates="interventions", 
+        "Technicien",
+        back_populates="interventions",
         lazy="select"
     )
-    
+
     client: Optional["Client"] = relationship(
-        "Client", 
-        back_populates="interventions", 
+        "Client",
+        back_populates="interventions",
         lazy="select"
     )
-    
+
+    equipements_assoc = relationship(
+        "InterventionEquipement",
+        back_populates="intervention",
+        cascade="all, delete-orphan",
+        lazy="dynamic",
+    )
+
     contrat: Optional["Contrat"] = relationship(
-        "Contrat", 
+        "Contrat",
         back_populates="interventions", 
         lazy="select"
     )
@@ -222,11 +230,11 @@ class Intervention(Base):
     
     # Relations de traçabilité (1:N) - lazy dynamic pour volumes
     documents = relationship(
-        "Document", 
-        back_populates="intervention", 
+        "Document",
+        back_populates="intervention",
         cascade="all, delete-orphan",
         lazy="dynamic",
-        order_by="desc(Document.uploaded_at)"
+        order_by="desc(Document.date_upload)"
     )
     
     historiques = relationship(
@@ -238,11 +246,11 @@ class Intervention(Base):
     )
     
     notifications = relationship(
-        "Notification", 
-        back_populates="intervention", 
+        "Notification",
+        back_populates="intervention",
         cascade="all, delete-orphan",
         lazy="dynamic",
-        order_by="desc(Notification.created_at)"
+        order_by="desc(Notification.date_envoi)"
     )
     
     # Relations stock et consommables (1:N)

--- a/app/models/intervention_equipement.py
+++ b/app/models/intervention_equipement.py
@@ -1,0 +1,67 @@
+"""
+Association InterventionEquipement : lien many-to-many entre interventions et équipements.
+
+Permet de suivre les équipements concernés par une intervention au-delà de
+l'équipement principal.
+"""
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Dict, Any
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, Index
+from sqlalchemy.orm import relationship
+
+from app.db.database import Base
+
+if TYPE_CHECKING:  # pragma: no cover - uniquement pour les types
+    from .intervention import Intervention
+    from .equipement import Equipement
+
+
+class InterventionEquipement(Base):
+    """Table d'association interventions ↔ équipements."""
+
+    __tablename__ = "interventions_equipements"
+    __table_args__ = (
+        Index("idx_intervention_equipement", "intervention_id", "equipement_id"),
+    )
+
+    id: int = Column(Integer, primary_key=True, index=True)
+    intervention_id: int = Column(
+        Integer,
+        ForeignKey("interventions.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    equipement_id: int = Column(
+        Integer,
+        ForeignKey("equipements.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    created_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False, index=True)
+
+    intervention: "Intervention" = relationship(
+        "Intervention", back_populates="equipements_assoc", lazy="select"
+    )
+    equipement: "Equipement" = relationship(
+        "Equipement", back_populates="interventions_assoc", lazy="select"
+    )
+
+    def to_dict(self, include_relations: bool = False) -> Dict[str, Any]:
+        data = {
+            "id": self.id,
+            "intervention_id": self.intervention_id,
+            "equipement_id": self.equipement_id,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+        }
+        if include_relations:
+            data["intervention"] = (
+                self.intervention.to_dict() if self.intervention else None
+            )
+            data["equipement"] = self.equipement.to_dict() if self.equipement else None
+        return data
+
+
+__all__ = ["InterventionEquipement"]
+

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from .notification import Notification
     from .historique import HistoriqueIntervention
     from .stock import MouvementStock
+    from .audit import Audit
 
 
 class UserRole(str, enum.Enum):
@@ -127,27 +128,35 @@ class User(Base):
     
     # Relations de traçabilité (1:N) - lazy dynamic pour performances
     notifications = relationship(
-        "Notification", 
-        back_populates="user", 
+        "Notification",
+        back_populates="user",
         cascade="all, delete-orphan",
         lazy="dynamic",
-        order_by="desc(Notification.created_at)"
+        order_by="desc(Notification.date_envoi)"
     )
     
     historiques = relationship(
-        "HistoriqueIntervention", 
-        back_populates="user", 
+        "HistoriqueIntervention",
+        back_populates="user",
         cascade="all, delete-orphan",
         lazy="dynamic",
         order_by="desc(HistoriqueIntervention.horodatage)"
     )
-    
+
     mouvements_stock = relationship(
-        "MouvementStock", 
-        back_populates="user", 
+        "MouvementStock",
+        back_populates="user",
         cascade="all, delete-orphan",
         lazy="dynamic",
         order_by="desc(MouvementStock.date_mouvement)"
+    )
+
+    audits = relationship(
+        "Audit",
+        back_populates="user",
+        cascade="all, delete-orphan",
+        lazy="dynamic",
+        order_by="desc(Audit.created_at)"
     )
 
     def __repr__(self) -> str:

--- a/app/tests/test_audit_and_intervention_equipement.py
+++ b/app/tests/test_audit_and_intervention_equipement.py
@@ -1,0 +1,51 @@
+from app.models import (
+    Audit,
+    Intervention,
+    InterventionEquipement,
+    InterventionType,
+    User,
+    UserRole,
+    Equipement,
+)
+
+
+def test_audit_relation(db_session):
+    user = User(
+        username="auditor",
+        full_name="Auditor",
+        email="audit@example.com",
+        hashed_password="x",
+        role=UserRole.admin,
+    )
+    db_session.add(user)
+    db_session.commit()
+
+    audit = Audit(action="create", table_name="users", object_id=user.id, user=user)
+    db_session.add(audit)
+    db_session.commit()
+
+    assert audit.user_id == user.id
+    assert audit.user.username == "auditor"
+
+
+def test_intervention_equipement_link(db_session):
+    equip_principal = Equipement(nom="E1", type_equipement="T1", localisation="Site")
+    equip_second = Equipement(nom="E2", type_equipement="T2", localisation="Site")
+    db_session.add_all([equip_principal, equip_second])
+    db_session.flush()
+
+    intervention = Intervention(
+        titre="Test",
+        description="",
+        type_intervention=InterventionType.corrective,
+        equipement_id=equip_principal.id,
+    )
+    link = InterventionEquipement(intervention=intervention, equipement=equip_second)
+    db_session.add_all([intervention, link])
+    db_session.commit()
+
+    assert link.intervention_id == intervention.id
+    assert link.equipement_id == equip_second.id
+    assert intervention.equipements_assoc.count() == 1
+    assert equip_second.interventions_assoc.count() == 1
+


### PR DESCRIPTION
## Summary
- add Audit model and InterventionEquipement association
- wire new relationships into core models and expose through `__init__`
- provide Alembic migration and basic unit tests

## Testing
- `pytest app/tests/test_audit_and_intervention_equipement.py::test_audit_relation -q` *(fails: Mapper 'Mapper[User(users)]' has no property 'reports_created')*

------
https://chatgpt.com/codex/tasks/task_e_68936e209b0c8331af5746deaee84901